### PR TITLE
Add 'Link this cat!' functionality

### DIFF
--- a/Build-a-Cat/index.html
+++ b/Build-a-Cat/index.html
@@ -667,6 +667,7 @@
                 <input type="radio" id="girlBox" name="box" value="girl"><label for="girlBox">Girl</label><br>
                 <input type="radio" id="boyBox" name="box" value="boy"><label for="boyBox">Boy</label>
             </fieldset>
+            <div><a href="https://tad-carlucci.com/Build-a-Cat/" id="catlink">Link this cat!</a></div>
     </form>
     </body>
 </html>

--- a/Build-a-Cat/index.js
+++ b/Build-a-Cat/index.js
@@ -5,7 +5,7 @@ var earSel
 var wColorSel, wShapeSel
 var noBoxRad, girlBoxRad, boyBoxRad
 
-var canonical = window.location.href.split('#')[0]
+var canonical
 
 (function(){
     
@@ -51,6 +51,7 @@ var canonical = window.location.href.split('#')[0]
                                      wShapeSel.options[ wShapeSel.selectedIndex ].getAttribute('data-tag') + '.' +
                                      box
         document.getElementById('catlink').href = link
+        history.pushState({}, "", link)
                                      
     }
     
@@ -93,6 +94,7 @@ var canonical = window.location.href.split('#')[0]
 
     document.addEventListener('readystatechange', () => {
         if (document.readyState === 'complete') {
+            canonical = window.location.href.split('#')[0]
             headSel     = document.getElementById('head'        )
             furSel      = document.getElementById('fur'         )
             eColorSel   = document.getElementById('eyecolor'    )

--- a/Build-a-Cat/index.js
+++ b/Build-a-Cat/index.js
@@ -1,17 +1,27 @@
-(function(){
-    function doChange() {
-        var selected_head = document.getElementById('head'        ).options[document.getElementById('head'        ).selectedIndex].text
-        var fur           = document.getElementById('fur'         ).options[document.getElementById('fur'         ).selectedIndex].text
-        var eyecolor      = document.getElementById('eyecolor'    ).options[document.getElementById('eyecolor'    ).selectedIndex].text
-        var eyeshape      = document.getElementById('eyeshape'    ).options[document.getElementById('eyeshape'    ).selectedIndex].text
-        var pupil         = document.getElementById('pupil'       ).options[document.getElementById('pupil'       ).selectedIndex].text
-        var ear           = document.getElementById('ear'         ).options[document.getElementById('ear'         ).selectedIndex].text
-        var whiskercolor  = document.getElementById('whiskercolor').options[document.getElementById('whiskercolor').selectedIndex].text
-        var whiskershape  = document.getElementById('whiskershape').options[document.getElementById('whiskershape').selectedIndex].text
+var headSel
+var furSel
+var eColorSel, eShapeSel, ePupilSel
+var earSel
+var wColorSel, wShapeSel
+var noBoxRad, girlBoxRad, boyBoxRad
 
-        var noBox   = document.getElementById('noBox'  ).checked
-        var girlBox = document.getElementById('girlBox').checked
-        var boyBox  = document.getElementById('boyBox' ).checked
+var canonical = window.location.href.split('#')[0]
+
+(function(){
+    
+    function doChange() {
+        var selected_head = headSel.options[   headSel.selectedIndex   ].text
+        var fur           = furSel.options[    furSel.selectedIndex    ].text
+        var eyecolor      = eColorSel.options[ eColorSel.selectedIndex ].text
+        var eyeshape      = eShapeSel.options[ eShapeSel.selectedIndex ].text
+        var pupil         = ePupilSel.options[ ePupilSel.selectedIndex ].text
+        var ear           = earSel.options[    earSel.selectedIndex    ].text
+        var whiskercolor  = wColorSel.options[ wColorSel.selectedIndex ].text
+        var whiskershape  = wShapeSel.options[ wShapeSel.selectedIndex ].text
+
+        var noBox   = noBoxRad.checked
+        var girlBox = girlBoxRad.checked
+        var boyBox  = boyBoxRad.checked
         
         var head = (selected_head === 'Floofy') ? 'Floofy_head/' : ''
 
@@ -22,27 +32,124 @@
 
         document.getElementById('confetti').className = (fur.substring(0,11) === 'Confetti - ') ? 'show' : ''
 
-        if (noBox)
+        var box
+        if (noBox) {
             document.getElementById('boxlayer').style.visibility = "hidden"
-        else {
+            box = 0
+        } else {
             document.getElementById('boxlayer').src = "https://kittycats.ws/online/HUD_BOX_" + ((girlBox) ? "GIRL" : "BOY") + ".png"
             document.getElementById('boxlayer').style.visibility = "visible"
+            box = (girlBox) ? 1 : 2
+        }
+        var link = canonical + '#' + headSel.options[   headSel.selectedIndex   ].getAttribute('data-tag') + '.' +
+                                     furSel.options[    furSel.selectedIndex    ].getAttribute('data-tag') + '.' +
+                                     eColorSel.options[ eColorSel.selectedIndex ].getAttribute('data-tag') + '.' +
+                                     eShapeSel.options[ eShapeSel.selectedIndex ].getAttribute('data-tag') + '.' +
+                                     ePupilSel.options[ ePupilSel.selectedIndex ].getAttribute('data-tag') + '.' +
+                                     earSel.options[    earSel.selectedIndex    ].getAttribute('data-tag') + '.' +
+                                     wColorSel.options[ wColorSel.selectedIndex ].getAttribute('data-tag') + '.' +
+                                     wShapeSel.options[ wShapeSel.selectedIndex ].getAttribute('data-tag') + '.' +
+                                     box
+        document.getElementById('catlink').href = link
+                                     
+    }
+    
+    function makeCrcTable() {
+        var c
+        var crcTable = []
+        for(var n =0; n < 256; n++) {
+            c = n
+            for(var k =0; k < 8; k++) {
+                c = ((c&1) ? (0xEDB88320 ^ (c >>> 1)) : (c >>> 1))
+            }
+            crcTable[n] = c
+        }
+        return crcTable
+    }
+
+    function crc32(str) {
+        var crcTable = window.crcTable || (window.crcTable = makeCrcTable())
+        var crc = 0 ^ (-1)
+
+        for (var i = 0; i < str.length; i++ ) {
+            crc = (crc >>> 8) ^ crcTable[(crc ^ str.charCodeAt(i)) & 0xFF]
+        }
+
+        return (crc ^ (-1)) >>> 0
+    }
+
+    function addTags(sel, isShort = false) {
+        var children = sel.children
+        for (var i = 0; i < children.length; i++) {
+            var opt = children[i]
+            var tag = crc32(opt.value).toString()
+            if (isShort) {
+                tag = tag.substring(0, 3)
+            }
+            opt.setAttribute('data-tag', tag)
+            opt.setAttribute('data-index', i.toString())
         }
     }
 
     document.addEventListener('readystatechange', () => {
         if (document.readyState === 'complete') {
-            document.getElementById('head'        ).addEventListener('change', doChange)
-            document.getElementById('fur'         ).addEventListener('change', doChange)
-            document.getElementById('eyecolor'    ).addEventListener('change', doChange)
-            document.getElementById('eyeshape'    ).addEventListener('change', doChange)
-            document.getElementById('pupil'       ).addEventListener('change', doChange)
-            document.getElementById('ear'         ).addEventListener('change', doChange)
-            document.getElementById('whiskercolor').addEventListener('change', doChange)
-            document.getElementById('whiskershape').addEventListener('change', doChange)
-            document.getElementById('noBox'       ).addEventListener('change', doChange)
-            document.getElementById('girlBox'     ).addEventListener('change', doChange)
-            document.getElementById('boyBox'      ).addEventListener('change', doChange)
+            headSel     = document.getElementById('head'        )
+            furSel      = document.getElementById('fur'         )
+            eColorSel   = document.getElementById('eyecolor'    )
+            eShapeSel   = document.getElementById('eyeshape'    )
+            ePupilSel   = document.getElementById('pupil'       )
+            earSel      = document.getElementById('ear'         )
+            wColorSel   = document.getElementById('whiskercolor')
+            wShapeSel   = document.getElementById('whiskershape')
+            noBoxRad    = document.getElementById('noBox'       )
+            girlBoxRad  = document.getElementById('girlBox'     )
+            boyBoxRad   = document.getElementById('boyBox'      )
+            addTags(headSel,   true)
+            addTags(furSel         )
+            addTags(eColorSel      )
+            addTags(eShapeSel, true)
+            addTags(ePupilSel, true)
+            addTags(earSel         )
+            addTags(wColorSel      )
+            addTags(wShapeSel      )
+            headSel.addEventListener(   'change', doChange)
+            furSel.addEventListener(    'change', doChange)
+            eColorSel.addEventListener( 'change', doChange)
+            eShapeSel.addEventListener( 'change', doChange)
+            ePupilSel.addEventListener( 'change', doChange)
+            earSel.addEventListener(    'change', doChange)
+            wColorSel.addEventListener( 'change', doChange)
+            wShapeSel.addEventListener( 'change', doChange)
+            noBoxRad.addEventListener(  'change', doChange)
+            girlBoxRad.addEventListener('change', doChange)
+            boyBoxRad.addEventListener( 'change', doChange)
+            var hash = window.location.hash
+            if (hash.length > 1) {
+                var values = hash.substring(1).split('.')
+                if (values.length == 9) {
+                    headSel.selectedIndex   = headSel.querySelector(  '[data-tag="'+values[0]+'"]').getAttribute('data-index')
+                    furSel.selectedIndex    = furSel.querySelector(   '[data-tag="'+values[1]+'"]').getAttribute('data-index')
+                    eColorSel.selectedIndex = eColorSel.querySelector('[data-tag="'+values[2]+'"]').getAttribute('data-index')
+                    eShapeSel.selectedIndex = eShapeSel.querySelector('[data-tag="'+values[3]+'"]').getAttribute('data-index')
+                    ePupilSel.selectedIndex = ePupilSel.querySelector('[data-tag="'+values[4]+'"]').getAttribute('data-index')
+                    earSel.selectedIndex    = earSel.querySelector(   '[data-tag="'+values[5]+'"]').getAttribute('data-index')
+                    wColorSel.selectedIndex = wColorSel.querySelector('[data-tag="'+values[6]+'"]').getAttribute('data-index')
+                    wShapeSel.selectedIndex = wShapeSel.querySelector('[data-tag="'+values[7]+'"]').getAttribute('data-index')
+                    var box = parseInt(values[8])
+                    switch(box) {
+                        case 1:
+                            girlBoxRad.checked = true
+                            break
+                        case 2:
+                            boyBoxRad.checked = true
+                            break
+                        default:
+                            noBoxRad.checked = true
+                    }
+                    doChange()
+                }
+            }
+            document.getElementById('catlink').href = canonical
         }
     })
 }())

--- a/Build-a-Cat/service_worker.js
+++ b/Build-a-Cat/service_worker.js
@@ -1,4 +1,4 @@
-const cacheName = 'build-a-cat-v15'
+const cacheName = 'build-a-cat-v17'
 
 this.addEventListener('install', function(event) {
     event.waitUntil(


### PR DESCRIPTION
Implements client-side scripting for link sharing functionality, so users can copy and share links to a cat they've designed.

* Uses "quick" crc32 hash to generate (hopefully!) unique "tags" for each trait.
 <sup>Takes <1µs per trait, so even 800+ traits is still <1ms; even on a computer 1/50 the speed of mine the full set should still compute in under 50ms</sup>
  * For traits that are numerous (basically everything besides head shape, eye shape, and pupil), full crc32 is used as tag.
  * For head shape, eye shape, and pupil, first 3 characters of crc32 are used to minimize fragment length.
* Adds a link to the page below the trait selectors that can be copied to share the selected traits.
  * Canonical URI is stored to a global for link construction.
  * Link is constructed dynamically in `doChange()` to concatenate trait tags into the URI fragment, dot-delimited
* Variables are created in global scope for select/input nodes since they are now used in several places across functions (rather than calling `document.getElementById()` over and over).